### PR TITLE
Refactor the hexagon screen position math to be simpler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.darzalgames</groupId>
 	<artifactId>darzal-common</artifactId>
-	<version>0.5.6</version>
+	<version>0.5.7</version>
 	<name>Darzal Common</name>
 
 	<properties>

--- a/src/main/java/com/darzalgames/darzalcommon/hexagon/HexagonMath.java
+++ b/src/main/java/com/darzalgames/darzalcommon/hexagon/HexagonMath.java
@@ -6,8 +6,6 @@ public class HexagonMath {
 
 	/**
 	 * Convert the flat-top hexagon's logical coordinates to pixel coordinates
-	 * @param height The height component in the height:width ratio
-	 * @param width The width component in the height:width ratio
 	 * @param q The Q-axis coordinate of the hexagon
 	 * @param r The R-axis coordinate of the hexagon
 	 * @param hexagonWidth The width of the visual representation of the hexagon
@@ -16,16 +14,14 @@ public class HexagonMath {
 	 * @return A {@link Tuple} with the pixel coordinates for where this {@link Hexagon}'s visual representation should be drawn on the Stage 
 	 * 	relative to other hexagon's in the visual representation of the {@link HexagonMap})
 	 */
-	public static Tuple<Float, Float> getScreenPositionOnStage(float height, float width, int q, int r, float hexagonWidth, float hexagonHeight, float stageHeight) {
-		Tuple<Float, Float> position = getScreenPosition(height, width, q, r, hexagonWidth, hexagonHeight);
+	public static Tuple<Float, Float> getScreenPositionOnStage(int q, int r, float hexagonWidth, float hexagonHeight, float stageHeight) {
+		Tuple<Float, Float> position = getScreenPosition(q, r, hexagonWidth, hexagonHeight);
 		float y = stageHeight - position.f - hexagonHeight; // This math works from a top-left system and actors work from bottom-left, so we subtract from the screen height
 		return new Tuple<Float, Float>(position.e, y);
 	}
 
 	/**
 	 * Convert the flat-top hexagon's logical coordinates to pixel coordinates. The hex at coordinates (0, 0) is always located at position (0, 0)
-	 * @param height The height component in the height:width ratio
-	 * @param width The width component in the height:width ratio
 	 * @param q The Q-axis coordinate of the hexagon
 	 * @param r The R-axis coordinate of the hexagon
 	 * @param hexagonWidth The width of the visual representation of the hexagon
@@ -33,10 +29,10 @@ public class HexagonMath {
 	 * @return A {@link Tuple} with the screen position coordinates for where this {@link Hexagon}'s visual representation should be drawn
 	 * 	relative to other hexagon's in the visual representation of the {@link HexagonMap})
 	 */
-	public static Tuple<Float, Float> getScreenPosition(float width, float height, int q, int r, float hexagonWidth, float hexagonHeight) {
+	public static Tuple<Float, Float> getScreenPosition(int q, int r, float hexagonWidth, float hexagonHeight) {
 		float size = hexagonWidth/2f;
 		float x = size * (3f/2 * q);
-		float y = size * ((height/width)*q + ((height*2)/width) * r);
+		float y = size * ((hexagonHeight/hexagonWidth)*q + ((hexagonHeight*2)/hexagonWidth) * r);
 		return new Tuple<Float, Float>(x, y);
 	}
 	

--- a/src/test/java/com/darzalgames/darzalcommon/hexagon/HexagonMathTest.java
+++ b/src/test/java/com/darzalgames/darzalcommon/hexagon/HexagonMathTest.java
@@ -18,7 +18,7 @@ class HexagonMathTest {
     })
 	void getScreenPosition_variousCoordinatesAndPixelRatio_returnsExpectedPosition(int hexagonQ, int hexagonR, float expectedX, float expectedY) {
 		
-		Tuple<Float, Float> position = HexagonMath.getScreenPosition(8, 7, hexagonQ, hexagonR, 8, 7);
+		Tuple<Float, Float> position = HexagonMath.getScreenPosition(hexagonQ, hexagonR, 8, 7);
 		
 		assertEquals(expectedX, position.e);
 		assertEquals(expectedY, position.f);
@@ -35,7 +35,7 @@ class HexagonMathTest {
 		float width = 3f/2;
 		float height = (float) (Math.sqrt(3)/2f);
 		
-		Tuple<Float, Float> position = HexagonMath.getScreenPosition(width, height, hexagonQ, hexagonR, width, height);
+		Tuple<Float, Float> position = HexagonMath.getScreenPosition(hexagonQ, hexagonR, width, height);
 		
 		assertEquals(expectedX, position.e);
 		assertEquals(expectedY, position.f);
@@ -51,7 +51,7 @@ class HexagonMathTest {
     })
 	void getScreenPositionOnStage_variousCoordinatesAndPixelRatio_returnsExpectedPosition(int hexagonQ, int hexagonR, float expectedX, float expectedY, int stageHeight) {
 		
-		Tuple<Float, Float> position = HexagonMath.getScreenPositionOnStage(8, 7, hexagonQ, hexagonR, 8, 7, stageHeight);
+		Tuple<Float, Float> position = HexagonMath.getScreenPositionOnStage(hexagonQ, hexagonR, 8, 7, stageHeight);
 		
 		assertEquals(expectedX, position.e);
 		assertEquals(expectedY, position.f);


### PR DESCRIPTION
The doubled values for width and height were redundant